### PR TITLE
Define method_missing so that predicates and scopes can still be acce…

### DIFF
--- a/spec/selections/belongs_to_selection_spec.rb
+++ b/spec/selections/belongs_to_selection_spec.rb
@@ -90,6 +90,40 @@ describe Selections::BelongsToSelection do
           end
         end
       end
+
+      describe '.method_missing' do
+        context 'predicates' do
+          context 'when it starts with an existing selections name' do
+            it 'returns false' do
+              expect(subject.priority_lower?).to be_falsey
+            end
+          end
+
+          context 'when it does not start with an existing selections name' do
+            it 'raises an error' do
+              expect do
+                subject.other_selection?
+              end.to raise_error(NoMethodError)
+            end
+          end
+        end
+
+        context 'scopes' do
+          context 'when it starts with an existing selections name' do
+            it 'returns an empty array' do
+              expect(ticket_class.priority_lower).to eq([])
+            end
+          end
+
+          context 'when it does not start with an existing selections name' do
+            it 'raises an error' do
+              expect do
+                ticket_class.other_selection
+              end.to raise_error(NoMethodError)
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
…ssed during tests

* When tests are being run it is constantly deleting and reseeding the database without reloading the model
* Would like to find a way so it only responds to predicate/scope methods which should exist but I can not see a way to add a custom option to a belongs_to relationship so I can access options like system_code, etc