### PR TITLE
Update method_missing methods for has_many and belongs_to

### DIFF
--- a/lib/selections/belongs_to_selection.rb
+++ b/lib/selections/belongs_to_selection.rb
@@ -93,7 +93,7 @@ module Selections
           end
 
           def predicate_method?(method)
-            method[-1] == '?' && self.class.reflect_on_all_associations(:belongs_to).any? do |relationship|
+            method[-1] == '?' && self.class.reflect_on_all_associations.any? do |relationship|
               relationship.options[:class_name] == 'Selection' && method.to_s.starts_with?(relationship.name.to_s)
             end
           end
@@ -115,7 +115,7 @@ module Selections
           end
 
           def scope_method?(method)
-            self.reflect_on_all_associations(:belongs_to).any? do |relationship|
+            self.reflect_on_all_associations.any? do |relationship|
               relationship.options[:class_name] == 'Selection' && method.to_s.starts_with?(relationship.name.to_s)
             end
           end

--- a/lib/selections/has_many_selections.rb
+++ b/lib/selections/has_many_selections.rb
@@ -105,7 +105,7 @@ module Selections
           end
 
           def predicate_method?(method)
-            method[-1] == '?' && self.class.reflect_on_all_associations(:has_many).any? do |relationship|
+            method[-1] == '?' && self.class.reflect_on_all_associations.any? do |relationship|
               if ActiveRecord::VERSION::MAJOR > 4
                 relationship.options[:class_name] == 'Selection' && method.to_s.starts_with?(relationship.name.to_s.singularize)
               else
@@ -131,7 +131,7 @@ module Selections
           end
 
           def scope_method?(method)
-            self.reflect_on_all_associations(:has_many).any? do |relationship|
+            self.reflect_on_all_associations.any? do |relationship|
               if ActiveRecord::VERSION::MAJOR > 4
                 relationship.options[:class_name] == 'Selection' && method.to_s.starts_with?(relationship.name.to_s.singularize)
               else


### PR DESCRIPTION
* The method_missing attribute is added to the same model for has_many and belongs_to so they need to be checking both relationship types